### PR TITLE
working on mobile header

### DIFF
--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -1,23 +1,29 @@
 // external
+// import { useSelector } from 'react-redux;
 
 // mui
 import { IconButton, useMediaQuery } from '@mui/material';
 import AppBar from '@mui/material/AppBar';
 import Box from '@mui/material/Box';
 import Toolbar from '@mui/material/Toolbar';
+import { Typography } from '@mui/material';
+import LogoutRoundedIcon from '@mui/icons-material/LogoutRounded';
 import styles from './Header.module.css';
-import Logo from '../Logo/Logo'
+import { Logo } from '../Logo/Logo'
 // internal
 import useViewPort from 'hooks/useViewport';
-import Navigation from '../Navigation/Navigation.jsx';
+import UserInfo from 'components/UserInfo/UserInfo';
+//import { selectIsLoggedIn } from 'redux/auth/authSelectors';
 
 const Header = () => {
+  //const loggedIn = useSelector(selectIsLoggedIn);
   const { width } = useViewPort();
   const breakpoint = 319;
   const isLargeScreen = useMediaQuery('(min-width: 769px)');
-  //const isSmallScreen = useMediaQuery('min-width: 320px')
+  const isSmallScreen = useMediaQuery('(max-width: 319px)');
   
   return (
+    
     <Box sx={{ width: "100%" }}>
       <AppBar position="static"
         sx={{
@@ -29,7 +35,7 @@ const Header = () => {
           sx={{
             justifyContent: isLargeScreen ? 'unset' : 'space-between',
             backgroundColor: 'var(--primary-background-color)',
-            padding: isLargeScreen ? '80px 20px 0 20px' : '20px',
+            padding: isSmallScreen ? '15px' : (isLargeScreen ? '80px 20px 0 20px' : '20px'),
           }}
         >
           {width > breakpoint ? (
@@ -46,10 +52,28 @@ const Header = () => {
              marginTop: isLargeScreen ? 4 : 0,
           }}
           >
-            <Navigation />
+            <UserInfo/>
+            {/* <Navigation /> */}
           </Box>
         </Toolbar>
       </AppBar>
+      <Toolbar sx={{
+        display: 'flex',
+        justifyContent: 'flex-end',
+      }}>
+        <Typography sx={{
+          paddingRight: '10px',
+          borderRight: '2px solid #E0E0E0'
+        }}>UserName
+          {/* {userName} */}
+        </Typography>
+        <IconButton
+          // onClick={() => dispatch(logOut())}
+          // aria-label="logout"
+        >
+          <LogoutRoundedIcon/>
+          </IconButton>
+      </Toolbar>
     </Box>
   );
 };

--- a/src/components/Header/Header.module.css
+++ b/src/components/Header/Header.module.css
@@ -2,4 +2,3 @@
     display: flex;
     align-items: center;
 };
-

--- a/src/components/Logo/Logo.jsx
+++ b/src/components/Logo/Logo.jsx
@@ -35,5 +35,17 @@ const Logo = ({ className }) => {
   );
 };
 
+const TextLogo = () => {
+  return (
+    <div className={styles['text-logo-container']}>
+        <NavLink to='/Diary' className={styles['svg-link']}>
+          <SlimSVG />
+        </NavLink>
+        <NavLink to='/Diary' className={styles['svg-link']}>
+          <MomSVG />
+        </NavLink>
+        </div>
+  );
+};
 
-export default Logo;
+export {Logo, TextLogo};

--- a/src/components/Logo/Logo.module.css
+++ b/src/components/Logo/Logo.module.css
@@ -60,3 +60,9 @@
         display: none;
     }
 }
+
+/* text logo component*/
+
+.text-logo-container {
+    display: flex;
+}

--- a/src/components/Navigation/Navigation.jsx
+++ b/src/components/Navigation/Navigation.jsx
@@ -1,18 +1,36 @@
 import React from 'react';
 import { NavLink } from 'react-router-dom';
+//import { useSelector } from 'react-redux';
+
 import css from './Navigation.module.css';
+//import { selectIsLoggedIn } from '../../redux/auth/authSelectors';
 
 function Navigation() {
+  //const loggedIn = useSelector(selectIsLoggedIn);
   return (
-    <div className={css.navContainer}>
-      <NavLink to="/login" className={css.navLink}>
-        log in
-      </NavLink>
-      <NavLink to="/register" className={css.navLink}>
-        registration
-      </NavLink>
-    </div>
+  <>
+    {/* {loggedIn
+      ?
+      <div className={css.navContainer}>
+        <NavLink to="/diary" className={css.navLink}>
+          diary
+         </NavLink>
+        <NavLink to="/calculator" className={css.navLink}>
+          calculator
+        </NavLink>
+      </div>
+      : */}
+      <div className={css.navContainer}>
+          <NavLink to="/login" className={css.navLink}>
+            log in
+          </NavLink>
+          <NavLink to="/register" className={css.navLink}>
+            registration
+          </NavLink>
+      </div >
+    {/* } */}
+  </>
   );
-}
+};
 
 export default Navigation;

--- a/src/components/UserInfo/UserInfo.jsx
+++ b/src/components/UserInfo/UserInfo.jsx
@@ -1,10 +1,9 @@
 // external
+import { useState } from 'react';
 //import { useDispatch } from 'react-redux';
 //import { useSelector } from 'react-redux';
-import LogoutRoundedIcon from '@mui/icons-material/LogoutRounded';
 import CompareArrowsIcon from '@mui/icons-material/CompareArrows';
-import { IconButton, Toolbar } from '@mui/material';
-import { Box, Typography } from '@mui/material';
+import { AppBar, IconButton, Toolbar } from '@mui/material';
 
 //internal
 /* import { selectUser } from '../../redux/auth/authSelectors';
@@ -12,34 +11,50 @@ import { logOut } from '../../redux/auth/authOperations';
 import useViewPort from 'utils/hooks';*/
 
 import Navigation from 'components/Navigation/Navigation';
+import { TextLogo } from 'components/Logo/Logo';
 import s from './UserInfo.module.css'
 
+
 const UserInfo = () => {
+    const [isOpen, setIsOpen] = useState(false);
+    const toggleNavbar = () => {
+      setIsOpen(!isOpen);
+    };
     /*const dispatch = useDispatch();
     const userName = useSelector(selectUser);
      const { width } = useViewPort();
      const breakpoint = 767; */
     return (
-        <Box>
-            <Toolbar>
-                <IconButton>
-                    <CompareArrowsIcon/>
-                </IconButton>
-                <div className={s.links}>
-                    <Navigation/>
+        <AppBar position="static"
+            sx={{boxShadow: 'none',}}
+        >
+            <Toolbar disableGutters={true}
+                sx={{
+                    padding: '0',
+                }}
+            >
+            {!isOpen &&
+                <div className={s.leftContent}>
+                    <TextLogo />
+                </div>}
+                <div className={s.rightContent}>
+                    <IconButton
+                        className={s.arrowButton}
+                        onClick={toggleNavbar}
+                        sx={{
+                        padding: '0',
+                    }}
+                    >
+                       <CompareArrowsIcon/>
+                    </IconButton>
+                </div>
+                <div>
+                    <div>
+                    {isOpen && <Navigation />} 
+                    </div>
                 </div>
             </Toolbar>
-            <Toolbar>
-            <Typography>UserName
-                {/* {userName} */}
-            </Typography>
-            <IconButton
-                // onClick={() => dispatch(logOut())}
-                // aria-label="logout"
-            >
-                <LogoutRoundedIcon/>
-            </IconButton></Toolbar>
-        </Box>
+        </AppBar>   
     )
 };
 

--- a/src/components/UserInfo/UserInfo.module.css
+++ b/src/components/UserInfo/UserInfo.module.css
@@ -1,3 +1,52 @@
-.open {
-    transform: translateX(-100%);
+.leftContent {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    margin-right: 90px;
 }
+
+.arrowButton {
+    background-color: transparent;
+    border: none;
+    cursor: pointer;
+    position: absolute;
+    top: 20px;
+    right: 20px;
+    z-index: 2;
+}
+
+.navbar {
+    position: fixed;
+    top: 0;
+    right: 0;
+    width: 0;
+    height: 100%;
+    background-color: #fff;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    transition: width 0.3s ease-in-out, right 0.3s ease-in-out;
+    z-index: 1;
+    overflow-x: hidden;
+}
+
+.links {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    margin-top: 20px;
+    width: 0;
+    transition: width 0.3s ease-in-out;
+}
+
+.links a {
+    text-decoration: none;
+    color: #000;
+}
+
+.open {
+    width: 300px;
+    /* Adjust to your desired width */
+}
+
+/* Add your other styles for Navigation as needed */


### PR DESCRIPTION
🤞🏽 add ternary to <navigation> based on logedIn redux state to switch links between login/register and diary/calc 🤞🏽 add userInfo for mobile
logic not finished for login, so it is a bit scrambled right now especially on tablet and desktop.